### PR TITLE
Once again, use Clang to fix the core_stacktrace failure in the test …

### DIFF
--- a/tests/dump_core.c
+++ b/tests/dump_core.c
@@ -15,7 +15,7 @@
 
 static char const *prefix = "/tmp/satyr.core";
 
-#if __clang__
+#if defined(__clang__)
 __attribute__((optnone))  
 #else
 __attribute__((optimize((0))))


### PR DESCRIPTION
Once again, use Clang to fix the core_stacktrace failure in the test suite.